### PR TITLE
[Feat] Implementing Tuple and Tuple arithmetic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod tuple;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,35 @@ mod tuple;
 
 use crate::tuple::Tuple;
 
+struct Environment {
+    gravity: Tuple,
+    wind: Tuple,
+}
+
+struct Projectile {
+    position: Tuple,
+    velocity: Tuple,
+}
+
+fn tick(environment: &Environment, projectile: &Projectile) -> Projectile {
+    Projectile {
+        position: projectile.position + projectile.velocity,
+        velocity: projectile.velocity + environment.gravity + environment.wind,
+    }
+}
+
 fn main() {
-    println!("Hello, world!");
+    let e = Environment {
+        gravity: Tuple::vector(0.0, -0.1, 0.0),
+        wind: Tuple::vector(-0.01, 0.0, 0.0),
+    };
+    let mut p = Projectile {
+        position: Tuple::vector(0.0, 1.0, 0.0),
+        velocity: Tuple::vector(1.0, 1.0, 0.0).norm(),
+    };
+
+    while p.position.y > 0.0 {
+        println!("{:?}", p.position);
+        p = tick(&e, &p);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod tuple;
 
+use crate::tuple::Tuple;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,3 +1,4 @@
+#[derive(PartialEq)]
 struct Tuple {
     x: f64,
     y: f64,
@@ -66,5 +67,15 @@ mod tests {
         let a = Tuple::vector(4.3, -4.2, 3.1);
         assert!(!a.is_point());
         assert!(a.is_vector());
+    }
+
+    #[test]
+    fn test_equality() {
+        let a = Tuple::new(4.3, -4.2, 3.1, 1);
+        let b = Tuple::new(4.3, -4.2, 3.1, 0);
+        let c = Tuple::new(4.3, -4.20000000000001, 3.1, 0);
+
+        assert!(a != b);
+        assert!(c != a && c != b && c == c);
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use std::ops::{Add, Sub};
 
 #[derive(PartialEq, Debug)]
 struct Tuple {
@@ -39,6 +39,19 @@ impl Add for Tuple {
             y: self.y + rhs.y,
             z: self.z + rhs.z,
             w: self.w + rhs.w,
+        }
+    }
+}
+
+impl Sub for Tuple {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self{
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+            z: self.z - rhs.z,
+            w: self.w - rhs.w,
         }
     }
 }
@@ -100,5 +113,23 @@ mod tests {
         let b = Tuple::new(1.0, 0.0, 1.0, 0);
         let c = Tuple::new(5.3, -4.2, 4.1, 1);
         assert_eq!(a + b, c);
+    }
+
+    #[test]
+    fn test_subtract_points_gives_vector() {
+        let a = Tuple::point(3.0, 2.0, 1.0);
+        let b = Tuple::point(5.0, 6.0, 7.0);
+        let c = Tuple::vector(-2.0, -4.0, -6.0);
+
+        assert_eq!(a - b, c);
+    }
+
+    #[test]
+    fn test_subtract_vector_from_point_gives_point() {
+        let a = Tuple::point(3.0, 2.0, 1.0);
+        let b = Tuple::vector(5.0, 6.0, 7.0);
+        let c = Tuple::point(-2.0, -4.0, -6.0);
+
+        assert_eq!(a - b, c);
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,4 +1,6 @@
-#[derive(PartialEq)]
+use std::ops::Add;
+
+#[derive(PartialEq, Debug)]
 struct Tuple {
     x: f64,
     y: f64,
@@ -25,6 +27,19 @@ impl Tuple {
 
     fn vector(x: f64, y: f64, z: f64) -> Tuple {
         Tuple { x, y, z, w: 0 }
+    }
+}
+
+impl Add for Tuple {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+            z: self.z + rhs.z,
+            w: self.w + rhs.w,
+        }
     }
 }
 
@@ -77,5 +92,13 @@ mod tests {
 
         assert!(a != b);
         assert!(c != a && c != b && c == c);
+    }
+
+    #[test]
+    fn test_add_tuples() {
+        let a = Tuple::new(4.3, -4.2, 3.1, 1);
+        let b = Tuple::new(1.0, 0.0, 1.0, 0);
+        let c = Tuple::new(5.3, -4.2, 4.1, 1);
+        assert_eq!(a + b, c);
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -11,7 +11,7 @@ struct Tuple {
 
 
 impl Tuple {
-    fn new(x: f64, y: f64, z: f64, w: u8) -> Tuple {
+    fn new(x: f64, y: f64, z: f64, w: u8) -> Self {
         Tuple { x, y, z, w }
     }
 
@@ -23,16 +23,16 @@ impl Tuple {
         self.w == 0
     }
 
-    fn point(x: f64, y: f64, z: f64) -> Tuple {
+    fn point(x: f64, y: f64, z: f64) -> Self {
         Tuple { x, y, z, w: 1 }
     }
 
-    fn vector(x: f64, y: f64, z: f64) -> Tuple {
+    fn vector(x: f64, y: f64, z: f64) -> Self {
         Tuple { x, y, z, w: 0 }
     }
 
-    fn origin() -> Tuple {
-        Tuple::vector(0.0, 0.0, 0.0)
+    fn origin() -> Self {
+        Self::vector(0.0, 0.0, 0.0)
     }
 
     fn abs(&self) -> f64 {
@@ -45,6 +45,10 @@ impl Tuple {
 
     fn dot(&self, rhs: Self) -> f64 {
         self.x * rhs.x + self.y * rhs.y + self.z * rhs.z + (self.w * rhs.w) as f64
+    }
+
+    fn cross(&self, rhs: Self) -> Self {
+        Self::vector(self.y * rhs.z - self.z * rhs.y, self.z * rhs.x - self.x * rhs.z, self.x * rhs.y - self.y * rhs.x)
     }
 }
 
@@ -247,5 +251,14 @@ mod tests {
         let b = Tuple::vector(2.0, 3.0, 4.0);
 
         assert_eq!(a.dot(b), 20.0);
+    }
+
+    #[test]
+    fn test_cross_product() {
+        let a = Tuple::vector(1.0, 2.0, 3.0);
+        let b = Tuple::vector(2.0, 3.0, 4.0);
+        let c = Tuple::vector(-1.0, 2.0, -1.0);
+        assert_eq!(a.cross(b), c);
+        assert_eq!(b.cross(a), -c);
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -8,6 +8,8 @@ struct Tuple {
     w: u8,
 }
 
+
+
 impl Tuple {
     fn new(x: f64, y: f64, z: f64, w: u8) -> Tuple {
         Tuple { x, y, z, w }
@@ -35,6 +37,10 @@ impl Tuple {
 
     fn abs(&self) -> f64 {
         (self.x * self.x + self.y * self.y + self.z * self.z + self.w as f64 * self.w as f64).sqrt()
+    }
+
+    fn norm(&self) -> Self {
+        *self / self.abs()
     }
 }
 
@@ -217,5 +223,17 @@ mod tests {
         assert_eq!(Tuple::vector(0.0, 0.0, 1.0).abs(), 1.0);
         assert_eq!(Tuple::vector(1.0, 2.0, 3.0).abs(), f64::sqrt(14.0));
         assert_eq!(Tuple::vector(-1.0, -2.0, -3.0).abs(), f64::sqrt(14.0));
+    }
+
+    #[test]
+    fn test_normalize() {
+        let a = Tuple::vector(4.0, 0.0, 0.0);
+        let b = Tuple::vector(1.0, 0.0, 0.0);
+
+        assert_eq!(a.norm(), b);
+
+        let c = Tuple::vector(1.0, 2.0, 3.0);
+        assert_eq!(c.norm(), c / f64::sqrt(14.0));
+        assert_eq!(c.norm().abs(), 1.0);
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -6,12 +6,24 @@ struct Tuple {
 }
 
 impl Tuple {
+    fn new(x: f64, y: f64, z: f64, w: u8) -> Tuple {
+        Tuple { x, y, z, w }
+    }
+
     fn is_point(&self) -> bool {
         self.w == 1
     }
 
     fn is_vector(&self) -> bool {
         self.w == 0
+    }
+
+    fn point(x: f64, y: f64, z: f64) -> Tuple {
+        Tuple { x, y, z, w: 1 }
+    }
+
+    fn vector(x: f64, y: f64, z: f64) -> Tuple {
+        Tuple { x, y, z, w: 0 }
     }
 }
 
@@ -22,7 +34,7 @@ mod tests {
 
     #[test]
     fn test_tuple_point() {
-        let a = Tuple { x: 4.3, y: -4.2, z: 3.1, w: 1 };
+        let a = Tuple::new(4.3, -4.2, 3.1, 1);
 
         assert_eq!(a.x, 4.3);
         assert_eq!(a.y, -4.2);
@@ -33,11 +45,25 @@ mod tests {
 
     #[test]
     fn test_tuple_vector() {
-        let a = Tuple { x: 4.3, y: -4.2, z: 3.1, w: 0 };
+        let a = Tuple::new(4.3, -4.2, 3.1, 0);
 
         assert_eq!(a.x, 4.3);
         assert_eq!(a.y, -4.2);
         assert_eq!(a.z, 3.1);
+        assert!(!a.is_point());
+        assert!(a.is_vector());
+    }
+
+    #[test]
+    fn test_point() {
+        let a = Tuple::point(4.3, -4.2, 3.1);
+        assert!(a.is_point());
+        assert!(!a.is_vector());
+    }
+
+    #[test]
+    fn test_vector() {
+        let a = Tuple::vector(4.3, -4.2, 3.1);
         assert!(!a.is_point());
         assert!(a.is_vector());
     }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -36,11 +36,15 @@ impl Tuple {
     }
 
     fn abs(&self) -> f64 {
-        (self.x * self.x + self.y * self.y + self.z * self.z + self.w as f64 * self.w as f64).sqrt()
+        (self.x * self.x + self.y * self.y + self.z * self.z + (self.w * self.w) as f64).sqrt()
     }
 
     fn norm(&self) -> Self {
         *self / self.abs()
+    }
+
+    fn dot(&self, rhs: Self) -> f64 {
+        self.x * rhs.x + self.y * rhs.y + self.z * rhs.z + (self.w * rhs.w) as f64
     }
 }
 
@@ -235,5 +239,13 @@ mod tests {
         let c = Tuple::vector(1.0, 2.0, 3.0);
         assert_eq!(c.norm(), c / f64::sqrt(14.0));
         assert_eq!(c.norm().abs(), 1.0);
+    }
+
+    #[test]
+    fn test_dot_product() {
+        let a = Tuple::vector(1.0, 2.0, 3.0);
+        let b = Tuple::vector(2.0, 3.0, 4.0);
+
+        assert_eq!(a.dot(b), 20.0);
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -132,4 +132,13 @@ mod tests {
 
         assert_eq!(a - b, c);
     }
+
+    #[test]
+    fn test_subtract_vector_from_vector_gives_vector() {
+        let a = Tuple::vector(3.0, 2.0, 1.0);
+        let b = Tuple::vector(5.0, 6.0, 7.0);
+        let c = Tuple::vector(-2.0, -4.0, -6.0);
+
+        assert_eq!(a - b, c);
+    }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Neg, Sub};
+use std::ops::{Add, Div, Mul, Neg, Sub};
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 struct Tuple {
@@ -51,7 +51,7 @@ impl Sub for Tuple {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        Self{
+        Self {
             x: self.x - rhs.x,
             y: self.y - rhs.y,
             z: self.z - rhs.z,
@@ -68,9 +68,36 @@ impl Neg for Tuple {
     }
 }
 
+impl Mul<f64> for Tuple {
+    type Output = Self;
+
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self {
+            x: self.x * rhs,
+            y: self.y * rhs,
+            z: self.z * rhs,
+            w: self.w,
+        }
+    }
+}
+
+impl Div<f64> for Tuple {
+    type Output = Self;
+
+    fn div(self, rhs: f64) -> Self::Output {
+        Self {
+            x: self.x / rhs,
+            y: self.y / rhs,
+            z: self.z / rhs,
+            w: 0,
+        }
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Div;
     use crate::tuple::Tuple;
 
     #[test]
@@ -115,7 +142,7 @@ mod tests {
         let b = Tuple::new(4.3, -4.2, 3.1, 0);
         let c = Tuple::new(4.3, -4.20000000000001, 3.1, 0);
 
-        assert!(a != b);
+        assert_ne!(a, b);
         assert!(c != a && c != b && c == c);
     }
 
@@ -161,5 +188,23 @@ mod tests {
 
         assert_eq!(-a, b);
         assert!((-a).is_vector());
+    }
+
+    #[test]
+    fn test_scalar_multiplication() {
+        let a = Tuple::vector(3.0, 2.0, 1.0);
+        let x = 2.0;
+        let c = Tuple::vector(6.0, 4.0, 2.0);
+
+        assert_eq!(a * x, c);
+    }
+
+    #[test]
+    fn test_scalar_division() {
+        let a = Tuple::vector(3.0, 2.0, 1.0);
+        let x = 2.0;
+        let c = Tuple::vector(1.5, 1.0, 0.5);
+
+        assert_eq!(a / x, c);
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -32,6 +32,10 @@ impl Tuple {
     fn origin() -> Tuple {
         Tuple::vector(0.0, 0.0, 0.0)
     }
+
+    fn abs(&self) -> f64 {
+        (self.x * self.x + self.y * self.y + self.z * self.z + self.w as f64 * self.w as f64).sqrt()
+    }
 }
 
 impl Add for Tuple {
@@ -94,10 +98,8 @@ impl Div<f64> for Tuple {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::ops::Div;
     use crate::tuple::Tuple;
 
     #[test]
@@ -206,5 +208,14 @@ mod tests {
         let c = Tuple::vector(1.5, 1.0, 0.5);
 
         assert_eq!(a / x, c);
+    }
+
+    #[test]
+    fn test_abs() {
+        assert_eq!(Tuple::vector(1.0, 0.0, 0.0).abs(), 1.0);
+        assert_eq!(Tuple::vector(0.0, 1.0, 0.0).abs(), 1.0);
+        assert_eq!(Tuple::vector(0.0, 0.0, 1.0).abs(), 1.0);
+        assert_eq!(Tuple::vector(1.0, 2.0, 3.0).abs(), f64::sqrt(14.0));
+        assert_eq!(Tuple::vector(-1.0, -2.0, -3.0).abs(), f64::sqrt(14.0));
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,6 +1,6 @@
-use std::ops::{Add, Sub};
+use std::ops::{Add, Neg, Sub};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Copy, Clone)]
 struct Tuple {
     x: f64,
     y: f64,
@@ -28,6 +28,10 @@ impl Tuple {
     fn vector(x: f64, y: f64, z: f64) -> Tuple {
         Tuple { x, y, z, w: 0 }
     }
+
+    fn origin() -> Tuple {
+        Tuple::vector(0.0, 0.0, 0.0)
+    }
 }
 
 impl Add for Tuple {
@@ -53,6 +57,14 @@ impl Sub for Tuple {
             z: self.z - rhs.z,
             w: self.w - rhs.w,
         }
+    }
+}
+
+impl Neg for Tuple {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::origin() - self
     }
 }
 
@@ -140,5 +152,14 @@ mod tests {
         let c = Tuple::vector(-2.0, -4.0, -6.0);
 
         assert_eq!(a - b, c);
+    }
+
+    #[test]
+    fn test_negation() {
+        let a = Tuple::vector(3.0, 2.0, 1.0);
+        let b = Tuple::vector(-3.0, -2.0, -1.0);
+
+        assert_eq!(-a, b);
+        assert!((-a).is_vector());
     }
 }

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,0 +1,44 @@
+struct Tuple {
+    x: f64,
+    y: f64,
+    z: f64,
+    w: u8,
+}
+
+impl Tuple {
+    fn is_point(&self) -> bool {
+        self.w == 1
+    }
+
+    fn is_vector(&self) -> bool {
+        self.w == 0
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::tuple::Tuple;
+
+    #[test]
+    fn test_tuple_point() {
+        let a = Tuple { x: 4.3, y: -4.2, z: 3.1, w: 1 };
+
+        assert_eq!(a.x, 4.3);
+        assert_eq!(a.y, -4.2);
+        assert_eq!(a.z, 3.1);
+        assert!(a.is_point());
+        assert!(!a.is_vector());
+    }
+
+    #[test]
+    fn test_tuple_vector() {
+        let a = Tuple { x: 4.3, y: -4.2, z: 3.1, w: 0 };
+
+        assert_eq!(a.x, 4.3);
+        assert_eq!(a.y, -4.2);
+        assert_eq!(a.z, 3.1);
+        assert!(!a.is_point());
+        assert!(a.is_vector());
+    }
+}

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,53 +1,52 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
 #[derive(PartialEq, Debug, Copy, Clone)]
-struct Tuple {
-    x: f64,
-    y: f64,
-    z: f64,
-    w: u8,
+pub struct Tuple {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub w: u8,
 }
 
 
-
 impl Tuple {
-    fn new(x: f64, y: f64, z: f64, w: u8) -> Self {
+    pub fn new(x: f64, y: f64, z: f64, w: u8) -> Self {
         Tuple { x, y, z, w }
     }
 
-    fn is_point(&self) -> bool {
+    pub fn is_point(&self) -> bool {
         self.w == 1
     }
 
-    fn is_vector(&self) -> bool {
+    pub fn is_vector(&self) -> bool {
         self.w == 0
     }
 
-    fn point(x: f64, y: f64, z: f64) -> Self {
+    pub fn point(x: f64, y: f64, z: f64) -> Self {
         Tuple { x, y, z, w: 1 }
     }
 
-    fn vector(x: f64, y: f64, z: f64) -> Self {
+    pub fn vector(x: f64, y: f64, z: f64) -> Self {
         Tuple { x, y, z, w: 0 }
     }
 
-    fn origin() -> Self {
+    pub fn origin() -> Self {
         Self::vector(0.0, 0.0, 0.0)
     }
 
-    fn abs(&self) -> f64 {
+    pub fn abs(&self) -> f64 {
         (self.x * self.x + self.y * self.y + self.z * self.z + (self.w * self.w) as f64).sqrt()
     }
 
-    fn norm(&self) -> Self {
+    pub fn norm(&self) -> Self {
         *self / self.abs()
     }
 
-    fn dot(&self, rhs: Self) -> f64 {
+    pub fn dot(&self, rhs: Self) -> f64 {
         self.x * rhs.x + self.y * rhs.y + self.z * rhs.z + (self.w * rhs.w) as f64
     }
 
-    fn cross(&self, rhs: Self) -> Self {
+    pub fn cross(&self, rhs: Self) -> Self {
         Self::vector(self.y * rhs.z - self.z * rhs.y, self.z * rhs.x - self.x * rhs.z, self.x * rhs.y - self.y * rhs.x)
     }
 }


### PR DESCRIPTION
Adds a Tuple-struct with the following methods:

```rust
Tuple::new
Tuple::is_point
Tuple::is_vector
Tuple::point
Tuple::vector
Tuple::origin
Tuple::abs
Tuple::norm
Tuple::dot
Tuple::cross
```

Also implements the following operations:

```rust
Tuple + Tuple
Tuple - Tuple
Tuple * f64
Tuple / f64
-Tuple
```

As an example of usage, the main method contains a small "rust cannon" that shoots a projectile and logs the position until the projectile hits the ground. 